### PR TITLE
[ubicloud] Use ubicloud/runner instead of actions/runner

### DIFF
--- a/images/ubuntu/scripts/build/install-runner-package.sh
+++ b/images/ubuntu/scripts/build/install-runner-package.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
-download_url=$(resolve_github_release_asset_url "actions/runner" 'test("actions-runner-linux-'"$(get_arch "x64" "arm64")"'-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest")
+download_url=$(resolve_github_release_asset_url "ubicloud/runner" 'test("actions-runner-linux-'"$(get_arch "x64" "arm64")"'-[0-9]+\\.[0-9]{3}\\.[0-9]+\\.tar\\.gz$")' "latest")
 archive_name="${download_url##*/}"
 archive_path=$(download_with_retry "$download_url")
 


### PR DESCRIPTION
actions/runner repo has been forked to allow clients of that repo to update cache API URI. Since that fork will be used with upcoming images, updating actions/runner with ubicloud/runner

