### PR TITLE
[ubicloud] Try installing java till it is succeeded

### DIFF
--- a/images/ubuntu/scripts/build/install-java-tools.sh
+++ b/images/ubuntu/scripts/build/install-java-tools.sh
@@ -30,7 +30,11 @@ install_open_jdk() {
     local java_version=$1
 
     # Install Java from PPA repositories.
-    apt-get -y install temurin-${java_version}-jdk=\*
+    while ! apt-get -y install temurin-${java_version}-jdk=\*; do
+        echo "Installation of temurin-${java_version}-jdk failed. Retrying in 5 seconds..."
+        sleep 5
+    done
+
     java_version_path="/usr/lib/jvm/temurin-${java_version}-jdk-$(get_arch "amd64" "arm64")"
 
     java_toolcache_path="${AGENT_TOOLSDIRECTORY}/Java_Temurin-Hotspot_jdk"


### PR DESCRIPTION
Server for temurin java is flaky, it sometimes return error while trying to install it. Sample error is given below

`
Failed to fetch https://packages.adoptium.net/artifactory/deb/pool/main/t/temurin-8/temurin-8-jdk_8.0.422.0.0+5_arm64.deb Connection failed [IP: 104.18.20.66 443]
`

So, try installing via loop to make sure it is installed.
