### PR TITLE
Convert VHD to RAW by copying data content of VHD image

### DIFF
--- a/.github/workflows/ubicloud-image.yml
+++ b/.github/workflows/ubicloud-image.yml
@@ -215,11 +215,6 @@ jobs:
           sudo chmod +x /usr/bin/mc
           mc --version
 
-      - name: Install qemu tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-utils
-
       - name: Set MinIO root certificates
         run: |
           mkdir -p ~/.mc/certs/CAs
@@ -247,8 +242,17 @@ jobs:
 
           azcopy copy "$sas_token" "${{ env.MANAGED_IMAGE_NAME }}.vhd"
 
+      - name: Install vhdiinfo tool
+        run: |
+          sudo apt-get update
+          sudo apt install -y libvhdi-utils
+
       - name: Convert VHD to RAW
-        run: qemu-img convert -f vpc -O raw ${{ env.MANAGED_IMAGE_NAME }}.vhd ${{ env.MANAGED_IMAGE_NAME }}.raw
+        run: |
+          VHD_IMAGE_SIZE=$(vhdiinfo -v "${{ env.MANAGED_IMAGE_NAME }}.vhd" | grep "Media size" | sed -n 's/.*(\([0-9]\+\) bytes).*/\1/p')
+          BLOCK_SIZE=512
+          BLOCK_COUNT=$(( VHD_IMAGE_SIZE / BLOCK_SIZE ))
+          dd if="${{ env.MANAGED_IMAGE_NAME }}.vhd" of="${{ env.MANAGED_IMAGE_NAME }}.raw" bs=$BLOCK_SIZE count=$BLOCK_COUNT
 
       - name: Create MinIO bucket
         run: mc mb --ignore-existing ubicloud/ubicloud-images


### PR DESCRIPTION
We were using qemu-img convert tool to convert VHD image to RAW image. Though the tool doesn't work for the fixed VHD image we have. Since fixed VHD file only contains the data itself and footer, copying data part as the RAW image file. Content length of data part is found by vhdiinfo tool.

