### PR TITLE
Add a feature to display messages on the GitHub UI

### DIFF
--- a/images/ubuntu/scripts/ubicloud/setup-runner-user.sh
+++ b/images/ubuntu/scripts/ubicloud/setup-runner-user.sh
@@ -58,10 +58,22 @@ chmod +x ./actions-runner/run-withenv.sh
 cat <<EOT > ./actions-runner/start-hook.sh
 #!/bin/sh
 printenv | grep GITHUB | sudo tee /etc/.github_context >/dev/null || true
+if [[ -f ./actions-runner/.ubicloud_start_message ]]; then
+    cat ./actions-runner/.ubicloud_start_message
+fi
 EOT
 chmod +x ./actions-runner/start-hook.sh
 
-echo "ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/actions-runner/start-hook.sh" | sudo tee -a /etc/environment
+cat <<EOT > ./actions-runner/complete-hook.sh
+#!/bin/sh
+if [[ -f ./actions-runner/.ubicloud_complete_message ]]; then
+    cat ./actions-runner/.ubicloud_complete_message
+fi
+EOT
+chmod +x ./actions-runner/complete-hook.sh
+
+echo "ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/actions-runner/start-hook.sh
+ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/runner/actions-runner/complete-hook.sh" | sudo tee -a /etc/environment
 
 # runner script doesn't use global $PATH variable by default. It gets path from
 # secure_path at /etc/sudoers. Also script load .env file, so we are able to


### PR DESCRIPTION
GitHub Actions has workflow commands that let you send messages to the
GitHub UI. This can be helpful for giving feedback or information during
a workflow's execution to our customers. The control plane saves the
message to a file, and the start and complete hooks print them if the
files exist.

Since the file needs to be in workflow command format, GitHub Actions
automatically parses the output and shows the message in the UI.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-a-notice-message
